### PR TITLE
Upgrading to Python 3.13

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
         files: .*\.(yaml|yml)$
 
 -   repo: https://github.com/asottile/reorder_python_imports
-    rev: v2.6.0
+    rev: v3.15.0
     hooks:
     -   id: reorder-python-imports
         files: ^src/|tests/
@@ -27,14 +27,21 @@ repos:
 #         language: system
 #         pass_filenames: false
 
--   repo: local
-    hooks:
-    -   id: black
-        name: black
-        entry: black
-        files: ^src/|tests/
-        language: system
-        types: [python]
+# Disabling black because it's conflicting with reorder_python_imports. That
+# hook wants to add a blank line before the imports, and then black wants to
+# remove it.
+#
+# Choosing to prioritize reorder_python_imports hook since it can reduce
+# merge conflicts and black is too authoritarian.
+#
+# -   repo: local
+#     hooks:
+#     -   id: black
+#         name: black
+#         entry: black
+#         files: ^src/|tests/
+#         language: system
+#         types: [python]
 
 -   repo: local
     hooks:
@@ -50,7 +57,7 @@ repos:
         name: Tests
         entry: pytest
         language: system
-        stages: [push]
+        stages: [pre-push]
         pass_filenames: false
 
 # #65: support for git-secrets

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,6 @@ download_url = https://github.com/NASA-PDS/lasso-requirements/releases/
 classifiers =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.9
-    License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
 
 
@@ -33,22 +32,21 @@ classifiers =
 
 [options]
 install_requires =
-    emoji ~= 2.0.0
-    github3.py == 1.3.0  # Do not change this version without also changing it in github-actions-base
-    jinja2 < 3.1         # Do not change: Jinja2 ≥ 3.1 is incompatible with Sphinx ≅ 3.2.1
-    markdown2 ~= 2.4.3
-    mdutils ~= 1.2.2
+    emoji ~= 2.14.1      # Not sure why this is necessary given you can just type emoji literals in Python source code 🤷
+    github3.py == 4.0.1  # Do not change this version without also changing it in github-actions-base
+    jinja2 ~= 3.1.6
+    markdown2 ~= 2.5.3
+    mdutils ~= 1.8.0
 
 
 # Change this to False if you use things like __file__ or __path__—which you
-# shouldn't use anyway, because that's what ``pkg_resources`` is for 🙂
+# shouldn't use anyway, because that's what ``importlib`` is for 🙂
 zip_safe = True
 include_package_data = True
-namespace_packages = lasso
 package_dir =
     = src
 packages = find_namespace:
-python_requires = >= 3.9
+python_requires = >= 3.13
 
 [options.extras_require]
 dev =

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ install_requires =
     jinja2 ~= 3.1.6
     markdown2 ~= 2.5.3
     mdutils ~= 1.8.0
+    packaging ~= 20.9    # Stick with 20; newer versions of packaging do not work with lasso-requirements
 
 
 # Change this to False if you use things like __file__ or __path__—which you

--- a/src/lasso/__init__.py
+++ b/src/lasso/__init__.py
@@ -1,4 +1,2 @@
 # encoding: utf-8
 """PDS "Lasso" 🤠 namespace."""
-
-__import__("pkg_resources").declare_namespace(__name__)

--- a/src/lasso/html/md_to_html.py
+++ b/src/lasso/html/md_to_html.py
@@ -2,7 +2,7 @@
 import emoji
 from jinja2 import Template
 from markdown2 import Markdown
-from pkg_resources import resource_string
+import importlib.resources
 
 
 def md_to_html(in_file, out_file, template_kargs):
@@ -16,7 +16,7 @@ def md_to_html(in_file, out_file, template_kargs):
         html_emojized_str = emoji.emojize(html_str, use_aliases=True)
         template_kargs["requirements_html"] = html_emojized_str
 
-    template = Template(resource_string(__name__, "REQUIREMENTS.html.template").decode("utf-8"))
+    template = Template(importlib.resources.files(__name__).joinpath("REQUIREMENTS.html.template").read_text())
     with open(out_file, "w") as f_out:
         html_str = template.render(template_kargs)
         f_out.write(html_str)

--- a/src/lasso/requirements/__init__.py
+++ b/src/lasso/requirements/__init__.py
@@ -1,5 +1,5 @@
 # encoding: utf-8
 """PDS Lasso Requirements."""
-import pkg_resources
+import importlib.resources
 
-__version__ = VERSION = pkg_resources.resource_string(__name__, "VERSION.txt").decode("utf-8").strip()
+__version__ = VERSION = importlib.resources.files(__name__).joinpath("VERSION.txt").read_text().strip()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39, docs, lint
+envlist = 313, docs, lint
 isolated_build = True
 
 [testenv]
@@ -10,7 +10,7 @@ commands = pytest
 [testenv:docs]
 deps = .[dev]
 whitelist_externals = python
-commands = python setup.py build_sphinx
+commands = sphinx-build --builder html docs/source docs/build
 
 [testenv:lint]
 deps = pre-commit
@@ -19,6 +19,6 @@ commands=
 skip_install = true
 
 [testenv:dev]
-basepython = python3.9
+basepython = python3.13
 usedevelop = True
 deps = .[dev]


### PR DESCRIPTION
## 🗒️ Summary

Upgrades from supporting Python 3.9 to Python 3.13.

## ⚙️ Test Data and/or Report

This tool is used by the Roundup Action. See successful Roundup runs at

- Stable: https://github.com/nasa-pds-engineering-node/epitome/actions/runs/16601184002
- Unstable: https://github.com/nasa-pds-engineering-node/epitome/actions/runs/14842393866

## ♻️ Related Issues

- https://github.com/NASA-PDS/template-repo-python/issues/105