### PR TITLE
Another attempt at a Python 3.13 upgrade

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,6 +1,6 @@
 PDS Lasso Requirements
 
-Copyright © 2023, California Institute of Technology ("Caltech").
+Copyright © 2023–2025, California Institute of Technology ("Caltech").
 U.S. Government sponsorship acknowledged.
 
 All rights reserved.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,8 +18,8 @@
 # -- Project information -----------------------------------------------------
 
 # TODO - Update with your project name
-project = 'My PDS Project'
-copyright = '2022 California Institute of Technology'
+project = 'Lasso Requirements'
+copyright = '2023–2025 California Institute of Technology'
 author = 'NASA Planetary Data System'
 release = '0.0'
 version = '0.0'
@@ -37,11 +37,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.githubpages',
     'sphinx.ext.autosummary',
-    'sphinx_rtd_theme'
 ]
-
-# Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -68,8 +64,8 @@ html_logo = '_static/images/PDS_Planets.png'
 # TODO - Update with your user/org and repo
 html_context = {
     'display_github': True,
-    "github_user": "nasa-pds",
-    "github_repo": "template-repo-python",
+    "github_user": "NASA-PDS",
+    "github_repo": "lasso-requirements",
     "github_version": "main/docs/source/"
 }
 
@@ -79,8 +75,6 @@ html_css_files = [
 
 html_theme_options = {
     'canonical_url': '',
-    'logo_only': False,
-    'display_version': True,
     'prev_next_buttons_location': 'bottom',
     'style_external_links': False,
     # Toc options

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ url = https://github.com/NASA-PDS/lasso-requirements
 download_url = https://github.com/NASA-PDS/lasso-requirements/releases/
 classifiers =
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.13
     Operating System :: OS Independent
 
 
@@ -35,9 +35,9 @@ install_requires =
     emoji ~= 2.14.1      # Not sure why this is necessary given you can just type emoji literals in Python source code 🤷
     github3.py == 4.0.1  # Do not change this version without also changing it in github-actions-base
     jinja2 ~= 3.1.6
-    markdown2 ~= 2.5.3
+    markdown2 ~= 2.5.4
     mdutils ~= 1.8.0
-    packaging ~= 20.9    # Stick with 20; newer versions of packaging do not work with lasso-requirements
+    packaging ~= 25.0
 
 
 # Change this to False if you use things like __file__ or __path__—which you
@@ -51,23 +51,22 @@ python_requires = >= 3.13
 
 [options.extras_require]
 dev =
-    black
-    flake8
-    flake8-bugbear
-    flake8-docstrings
-    pep8-naming
-    mypy
-    pydocstyle
-    coverage
-    pytest
-    pytest-cov
-    pytest-watch
-    pytest-xdist
-    pre-commit
-    sphinx
-    sphinx-rtd-theme
-    tox
-    types-setuptools
+    flake8~=7.3.0
+    flake8-bugbear~=24.12.12
+    flake8-docstrings~=1.7.0
+    pep8-naming~=0.13.3
+    mypy~=1.14.1
+    pydocstyle~=6.3.0
+    coverage~=7.3.0
+    pytest~=7.4.0
+    pytest-cov~=4.1.0
+    pytest-watch~=4.2.0
+    pytest-xdist~=3.3.1
+    pre-commit~=3.3.3
+    sphinx~=8.2.3
+    sphinx-rtd-theme~=3.0.2
+    tox~=4.11.0
+
 
 [options.entry_points]
 console_scripts =

--- a/src/lasso/html/md_to_html.py
+++ b/src/lasso/html/md_to_html.py
@@ -1,8 +1,9 @@
 """Markdown to HTML."""
+import importlib.resources
+
 import emoji
 from jinja2 import Template
 from markdown2 import Markdown
-import importlib.resources
 
 
 def md_to_html(in_file, out_file, template_kargs):


### PR DESCRIPTION
## 🗒️ Summary

When making a release, some steps failed. Looking more closely, the upgrade to Python 3.13 was incomplete. This PR corrects that. Specifically:

- Adds and upgrades dependencies, especially `packaging` to 25.0 (20.0 is incompatible with the upgrade to Python 3.13)
- Adheres to the weirdly arbitrary reorder-python-imports rules
- Replaces 3.9 in the Trove classifiers with 3.13
- Tweaks some documentation (`NOTICE.txt, Sphinx `conf.py`)


## ⚙️ Test Data and/or Report

```console
$ tox
…
  313: OK (3.04=setup[1.66]+cmd[1.38] seconds)
  docs: OK (1.75=setup[1.37]+cmd[0.38] seconds)
  lint: OK (1.20=setup[0.00]+cmd[1.20] seconds)
  congratulations :) (6.05 seconds)
```

## ♻️ Related Issues

- https://github.com/NASA-PDS/template-repo-python/issues/105